### PR TITLE
Update areafac_c, areafac_ce in halo in dynamics

### DIFF
--- a/cicecore/cicedyn/dynamics/ice_transport_remap.F90
+++ b/cicecore/cicedyn/dynamics/ice_transport_remap.F90
@@ -1927,17 +1927,18 @@
          jse_br =  0
 
          ! area scale factor
+         ! earea, narea valid on halo
 
-         do j = jlo-1, jhi
-         do i = ilo, ihi
+         do j = 1, ny_block
+         do i = 1, nx_block
             areafac_c(i,j) = narea(i,j)
          enddo
          enddo
 
          ! area scale factor for other edge (east)
          
-         do j = jlo-1, jhi+1
-            do i = ilo-1, ihi
+         do j = 1, ny_block
+         do i = 1, nx_block
             areafac_ce(i,j) = earea(i,j)
          enddo
          enddo
@@ -1978,17 +1979,18 @@
          jse_br = -1
 
          ! area scale factors
+         ! earea, narea valid on halo
 
-         do j = jlo, jhi
-         do i = ilo-1, ihi
+         do j = 1, ny_block
+         do i = 1, nx_block
             areafac_c(i,j) = earea(i,j)
          enddo
          enddo
 
          ! area scale factor for other edge (north)
 
-         do j = jlo-1, jhi
-         do i = ilo-1, ihi+1
+         do j = 1, ny_block
+         do i = 1, nx_block
             areafac_ce(i,j) = narea(i,j)
          enddo
          enddo

--- a/cicecore/cicedyn/infrastructure/ice_grid.F90
+++ b/cicecore/cicedyn/infrastructure/ice_grid.F90
@@ -82,14 +82,14 @@
          dyE    , & ! height of E-cell through the middle (m)
          HTE    , & ! length of eastern edge of T-cell (m)
          HTN    , & ! length of northern edge of T-cell (m)
-         tarea  , & ! area of T-cell (m^2)
-         uarea  , & ! area of U-cell (m^2)
-         narea  , & ! area of N-cell (m^2)
-         earea  , & ! area of E-cell (m^2)
-         tarear , & ! 1/tarea
-         uarear , & ! 1/uarea
-         narear , & ! 1/narea
-         earear , & ! 1/earea
+         tarea  , & ! area of T-cell (m^2), valid in halo
+         uarea  , & ! area of U-cell (m^2), valid in halo
+         narea  , & ! area of N-cell (m^2), valid in halo
+         earea  , & ! area of E-cell (m^2), valid in halo
+         tarear , & ! 1/tarea, valid in halo
+         uarear , & ! 1/uarea, valid in halo
+         narear , & ! 1/narea, valid in halo
+         earear , & ! 1/earea, valid in halo
          tarean , & ! area of NH T-cells
          tareas , & ! area of SH T-cells
          ULON   , & ! longitude of velocity pts, NE corner of T pts (radians)
@@ -101,7 +101,7 @@
          ELON   , & ! longitude of center of east face of T pts (radians)
          ELAT   , & ! latitude of center of east face of T pts (radians)
          ANGLE  , & ! for conversions between POP grid and lat/lon
-         ANGLET , & ! ANGLE converted to T-cells
+         ANGLET , & ! ANGLE converted to T-cells, valid in halo
          bathymetry      , & ! ocean depth, for grounding keels and bergs (m)
          ocn_gridcell_frac   ! only relevant for lat-lon grids
                              ! gridcell value of [1 - (land fraction)] (T-cell)
@@ -635,11 +635,23 @@
       call ice_HaloUpdate (uarea,              halo_info, &
                            field_loc_NEcorner, field_type_scalar, &
                            fillValue=c1,       tripoleOnly=.true.)
+      call ice_HaloUpdate (narea,              halo_info, &
+                           field_loc_Nface,    field_type_scalar, &
+                           fillValue=c1,       tripoleOnly=.true.)
+      call ice_HaloUpdate (earea,              halo_info, &
+                           field_loc_Eface,    field_type_scalar, &
+                           fillValue=c1,       tripoleOnly=.true.)
       call ice_HaloUpdate (tarear,             halo_info, &
                            field_loc_center,   field_type_scalar, &
                            fillValue=c1,       tripoleOnly=.true.)
       call ice_HaloUpdate (uarear,             halo_info, &
                            field_loc_NEcorner, field_type_scalar, &
+                           fillValue=c1,       tripoleOnly=.true.)
+      call ice_HaloUpdate (narear,             halo_info, &
+                           field_loc_Nface,    field_type_scalar, &
+                           fillValue=c1,       tripoleOnly=.true.)
+      call ice_HaloUpdate (earear,             halo_info, &
+                           field_loc_Eface,    field_type_scalar, &
                            fillValue=c1,       tripoleOnly=.true.)
 
       call ice_timer_stop(timer_bound)


### PR DESCRIPTION
I believe this fixes the issues in the updated remap advection.  The problem was that CICE was not bit-for-bit on different block sizes with the latest changes even though it was bit-for-bit for a fixed block size with different pes or decompositions.  This indicated a problem on the halo.  The problem existed with B, C, or CD grids in this branch.

The fix is to change the areafac_c and areafac_ce fields so they are defined everywhere, including in the complete halo.  The current version only sets areafac_c and areafac_ce on part of the halo (for reasons I don't understand).  earea and narea are defined everywhere on the halo, so we can set areafac_c and areafac_ce in the complete halo trivially.

The changes in ice_grid.F90 are not required for this fix, but are probably needed for symmetry testing (which we don't do automatically yet).

Somewhere in the remap advection special cases, areafac_c or (more likely) areafac_ce must have been used on a point where it wasn't set properly on the halo.  And that's why different block sizes produced different answers.  With these fixes, that problem goes away.  That doesn't guarantee that all the special cases are implemented correctly in terms of offsets and answers, but this does fix the block size reproducibility issue.

I'm running a complete test suite now and will have more results soon.  Feel free to merge and/or test this in the areafact branch in the mean time.  I think it's safe to do so.  I will run a complete test suite, we probably want to also rerun the QCs and any other manual testing just be really sure the final thing we want to merge is OK.